### PR TITLE
Add keyname option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ var createIndexer = require('level-simple-indexes')
 var db = sublevel(memdb(), { valueEncoding: 'json' })
 var indexdb = sublevel(db, 'indexes')
 var indexer = createIndexer(indexdb, {
+  // keyName: 'key' <-- optional way to override which attribute in `data` is the key
   properties: ['ingredients.sauce', 'ingredients.toppings.meat'],
   map: function (key, next) {
     db.get(key, next)

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function Indexer (db, opts) {
     values: opts.values || true,
     map: opts.map
   }
+  this.keyName = opts.keyName || 'key'
 
   this.indexes = {}
   opts.properties.forEach(function (key) {
@@ -63,7 +64,7 @@ Indexer.prototype.modifyIndexes = function (type, obj, cb) {
   }
 
   function modify (key, value, cb) {
-    var doc = { key: obj.key }
+    var doc = { key: obj[self.keyName] }
     doc[key] = value
     self.indexes[key][type](doc, cb)
   }

--- a/test.js
+++ b/test.js
@@ -200,3 +200,28 @@ test('remove indexes of deeply nested properties', function (t) {
     })
   })
 })
+
+test('use a custom keyname', function (t) {
+  var db = sublevel(memdb(), { valueEncoding: 'json' })
+  var indexdb = sublevel(db, 'indexes')
+  var indexer = createIndexer(indexdb, {
+    keyName: 'id',
+    properties: ['title'],
+    map: function (key, next) {
+      db.get(key, next)
+    }
+  })
+
+  var data = { id: 'pizza', title: 'the best pizza' }
+  db.put(data.id, data, function (err) {
+    t.notOk(err)
+    indexer.addIndexes(data, function () {
+      indexer.findOne('title', 'the best pizza', function (err, result) {
+        t.notOk(err)
+        t.ok(result)
+        t.equal(result.id, 'pizza')
+        t.end()
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR adds the ability to choose the name of the key attribute.

Previously, this would fail:

```js
var db = sublevel(memdb(), { valueEncoding: 'json' })
var indexdb = sublevel(db, 'indexes')
var indexer = createIndexer(indexdb, {
  properties: ['ingredients.sauce', 'ingredients.toppings.meat'],
  map: function (key, next) {
    db.get(key, next)
  }
})

var data = {
  id: 'pizza', // <--- problem
  ingredients: {
    sauce: 'tomato',
    toppings: {
      cheese: 'cheddar',
      meat: ['pepperoni', 'sausage'],
      vegetables: ['onion', 'bell pepper']
    }
  }
}

db.put(data.key, data, function (err) {
  indexer.addIndexes(data, function () {
    indexer.findOne('ingredients.toppings.meat', 'sausage', function (err, result) {
      console.log(result)
    })
  })
})
```

It expects `key` instead of `id`. With this PR I can specify:

```js
var indexer = createIndexer(indexdb, {
  keyName: 'id',
  properties: ['ingredients.sauce', 'ingredients.toppings.meat'],
  map: function (key, next) {
    db.get(key, next)
  }
})
```