### PR TITLE
Allow passing callback from `.find` into level-indexer

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,9 +23,9 @@ function Indexer (db, opts) {
   })
 }
 
-Indexer.prototype.find = function (index, opts) {
+Indexer.prototype.find = function (index, opts, cb) {
   if (!this.indexes[index]) throw new Error(index + ' index not found')
-  return this.indexes[index].find(opts)
+  return this.indexes[index].find(opts, cb)
 }
 
 Indexer.prototype.findOne = function (index, opts, cb) {


### PR DESCRIPTION
Once this is merged and published, https://github.com/sethvincent/level-model/commit/91ba13a8026d9efe544758573987e7857f45080f will work.